### PR TITLE
Fix `updateFrameAsync` switch case logic, add comments detailing forked code changes

### DIFF
--- a/cogs.js
+++ b/cogs.js
@@ -6,6 +6,7 @@ module.exports = {
         name: 'babel',
         only: 'react-list.es6',
         options: {
+          comments: false,
           presets: ['@babel/preset-env', '@babel/preset-react'],
           plugins: [
             '@babel/plugin-proposal-class-properties',
@@ -40,7 +41,7 @@ module.exports = {
       {
         name: 'babel',
         only: 'docs/index.es6',
-        options: { presets: ['@babel/preset-env', '@babel/preset-react'] }
+        options: { comments: false, presets: ['@babel/preset-env', '@babel/preset-react'] }
       },
       {
         name: 'concat-commonjs',

--- a/docs/index.js
+++ b/docs/index.js
@@ -31487,10 +31487,7 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
     y: 'height'
   };
 
-  var NOOP = function NOOP() {}; // If a browser doesn't support the `options` argument to
-  // add/removeEventListener, we need to check, otherwise we will
-  // accidentally set `capture` with a truthy value.
-
+  var NOOP = function NOOP() {};
 
   var PASSIVE = function () {
     if (typeof window === 'undefined') return false;
@@ -31504,8 +31501,7 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
         }
 
       });
-    } catch (e) {// noop
-    }
+    } catch (e) {}
 
     return hasSupport;
   }() ? {
@@ -31570,7 +31566,7 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
     });
   };
 
-  module.exports = (_temp = _class = /*#__PURE__*/function (_Component) {
+  module.exports = (_temp = _class = function (_Component) {
     _inherits(ReactList, _Component);
 
     var _super = _createSuper(ReactList);
@@ -31605,8 +31601,7 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
     _createClass(ReactList, [{
       key: "componentDidMount",
       value: function componentDidMount() {
-        this.updateFrame = this.updateFrame.bind(this); // @superhuman fork: Call this function instead of `updateFrameAndClearCache`
-
+        this.updateFrame = this.updateFrame.bind(this);
         this.updateFrameAsync = this.updateFrameAsync.bind(this);
         window.addEventListener('resize', this.updateFrameAsync);
         this.updateFrame(this.scrollTo.bind(this, this.props.initialIndex));
@@ -31616,9 +31611,7 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
       value: function componentDidUpdate(prevProps) {
         var _this2 = this;
 
-        // Viewport scroll is no longer useful if axis changes
-        if (this.props.axis !== prevProps.axis) this.clearSizeCache(); // If the list has reached an unstable state, prevent an infinite loop.
-
+        if (this.props.axis !== prevProps.axis) this.clearSizeCache();
         if (this.unstable) return;
 
         if (++this.updateCounter > MAX_SYNC_UPDATES) {
@@ -31646,8 +31639,7 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
       value: function componentWillUnmount() {
         window.removeEventListener('resize', this.updateFrameAsync);
         this.scrollParent.removeEventListener('scroll', this.updateFrameAsync, PASSIVE);
-        this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE); // @superhuman fork: Clean up anything that was added in forked code.
-
+        this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE);
         window.cancelAnimationFrame(this.frameRequested);
       }
     }, {
@@ -31671,7 +31663,6 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
     }, {
       key: "getScrollPosition",
       value: function getScrollPosition() {
-        // Cache scroll position as this causes a forced synchronous layout.
         if (typeof this.cachedScrollPosition === 'number') {
           return this.cachedScrollPosition;
         }
@@ -31679,10 +31670,7 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
         var scrollParent = this.scrollParent;
         var axis = this.props.axis;
         var scrollKey = SCROLL_START_KEYS[axis];
-        var actual = scrollParent === window ? // Firefox always returns document.body[scrollKey] as 0 and Chrome/Safari
-        // always return document.documentElement[scrollKey] as 0, so take
-        // whichever has a value.
-        document.body[scrollKey] || document.documentElement[scrollKey] : scrollParent[scrollKey];
+        var actual = scrollParent === window ? document.body[scrollKey] || document.documentElement[scrollKey] : scrollParent[scrollKey];
         var max = this.getScrollSize() - this.props.scrollParentViewportSizeGetter(this);
         var scroll = Math.max(0, Math.min(actual, max));
         var el = this.getEl();
@@ -31753,11 +31741,7 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
 
         var itemEls = this.items.children;
         if (!itemEls.length) return {};
-        var firstEl = itemEls[0]; // Firefox has a problem where it will return a *slightly* (less than
-        // thousandths of a pixel) different size for the same element between
-        // renders. This can cause an infinite render loop, so only change the
-        // itemSize when it is significantly different.
-
+        var firstEl = itemEls[0];
         var firstElSize = firstEl[OFFSET_SIZE_KEYS[axis]];
         var delta = Math.abs(firstElSize - itemSize);
         if (isNaN(delta) || delta >= 1) itemSize = firstElSize;
@@ -31780,15 +31764,6 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
       value: function clearSizeCache() {
         this.cachedScrollPosition = null;
       }
-      /*
-       * @superhuman fork
-       *
-       * This function only exists on this fork, and is a substitute for
-       * `updateFrameAndClearCache` (at the time of writing).
-       *
-       * Called by 'scroll' and 'resize' events, clears scroll position cache.
-       */
-
     }, {
       key: "updateFrameAsync",
       value: function updateFrameAsync() {
@@ -31799,13 +31774,6 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
         this.clearSizeCache();
         this.frameRequested = window.requestAnimationFrame(this.updateFrame);
       }
-      /*
-       * @superhuman fork
-       * This function only exists on this fork, and lets
-       * the `getVisibleRange` function return correct value
-       * after `updateFrameAsync` has finished setting state.
-       */
-
     }, {
       key: "waitForFrameUpdate",
       value: function waitForFrameUpdate() {
@@ -31843,13 +31811,6 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
             this.updateUniformFrame(cb);
             break;
         }
-        /*
-         * @superhuman fork
-         * The following block needs to run every time
-         * this function is called, (not just in the `default`
-         * case above), hence the `break`s instead of `return`s.
-         */
-
 
         if (this.onFrameUpdate) {
           this.onFrameUpdate();
@@ -31865,13 +31826,10 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
         if (prev) {
           prev.removeEventListener('scroll', this.updateFrameAsync);
           prev.removeEventListener('mousewheel', NOOP);
-        } // If we have a new parent, cached parent dimensions are no longer useful.
-
+        }
 
         this.clearSizeCache();
-        this.scrollParent.addEventListener('scroll', this.updateFrameAsync, PASSIVE); // You have to attach mousewheel listener to the scrollable element.
-        // Just an empty listener. After that onscroll events will be fired synchronously.
-
+        this.scrollParent.addEventListener('scroll', this.updateFrameAsync, PASSIVE);
         this.scrollParent.addEventListener('mousewheel', NOOP, PASSIVE);
       }
     }, {
@@ -31975,23 +31933,20 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
       key: "getSpaceBefore",
       value: function getSpaceBefore(index) {
         var cache = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-        if (cache[index] != null) return cache[index]; // Try the static itemSize.
-
+        if (cache[index] != null) return cache[index];
         var _this$state2 = this.state,
             itemSize = _this$state2.itemSize,
             itemsPerRow = _this$state2.itemsPerRow;
 
         if (itemSize) {
           return cache[index] = Math.floor(index / itemsPerRow) * itemSize;
-        } // Find the closest space to index there is a cached value for.
-
+        }
 
         var from = index;
 
         while (from > 0 && cache[--from] == null) {
           ;
-        } // Finally, accumulate sizes of items from - index.
-
+        }
 
         var space = cache[from] || 0;
 
@@ -32031,19 +31986,15 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
         var _this$state3 = this.state,
             from = _this$state3.from,
             itemSize = _this$state3.itemSize,
-            size = _this$state3.size; // Try the static itemSize.
-
-        if (itemSize) return itemSize; // Try the itemSizeGetter.
-
-        if (itemSizeGetter) return itemSizeGetter(index); // Try the cache.
-
-        if (index in cache) return cache[index]; // Try the DOM.
+            size = _this$state3.size;
+        if (itemSize) return itemSize;
+        if (itemSizeGetter) return itemSizeGetter(index);
+        if (index in cache) return cache[index];
 
         if (type === 'simple' && index >= from && index < from + size && items) {
           var itemEl = items.children[index - from];
           if (itemEl) return itemEl[OFFSET_SIZE_KEYS[axis]];
-        } // Try the itemSizeEstimator.
-
+        }
 
         if (itemSizeEstimator) return itemSizeEstimator(index, cache);
       }
@@ -32097,7 +32048,7 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
         var _this$state5 = this.state,
             from = _this$state5.from,
             size = _this$state5.size;
-        var items = []; // @superhuman fork: Pass `size` to the item renderer
+        var items = [];
 
         for (var i = 0; i < size; ++i) {
           items.push(itemRenderer(from + i, i, size));
@@ -32143,12 +32094,12 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
           WebkitTransform: transform,
           transform: transform
         };
-        return /*#__PURE__*/_react["default"].createElement("div", {
+        return _react["default"].createElement("div", {
           style: style,
           ref: function ref(c) {
             return _this5.el = c;
           }
-        }, /*#__PURE__*/_react["default"].createElement("div", {
+        }, _react["default"].createElement("div", {
           style: listStyle
         }, items));
       }
@@ -32174,12 +32125,12 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
   }), _defineProperty(_class, "defaultProps", {
     axis: 'y',
     itemRenderer: function itemRenderer(index, key) {
-      return /*#__PURE__*/_react["default"].createElement("div", {
+      return _react["default"].createElement("div", {
         key: key
       }, index);
     },
     itemsRenderer: function itemsRenderer(items, ref) {
-      return /*#__PURE__*/_react["default"].createElement("div", {
+      return _react["default"].createElement("div", {
         ref: ref
       }, items);
     },
@@ -32233,7 +32184,7 @@ function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Re
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 var renderItem = function renderItem(index, key) {
-  return /*#__PURE__*/_react["default"].createElement("div", {
+  return _react["default"].createElement("div", {
     key: key,
     className: 'item' + (index % 2 ? '' : ' even')
   }, index);
@@ -32244,7 +32195,7 @@ renderItem.toJSON = function () {
 };
 
 var renderSquareItem = function renderSquareItem(index, key) {
-  return /*#__PURE__*/_react["default"].createElement("div", {
+  return _react["default"].createElement("div", {
     key: key,
     className: 'square-item' + (index % 2 ? '' : ' even')
   }, index);
@@ -32271,7 +32222,7 @@ getWidth.toJSON = function () {
 };
 
 var renderVariableHeightItem = function renderVariableHeightItem(index, key) {
-  return /*#__PURE__*/_react["default"].createElement("div", {
+  return _react["default"].createElement("div", {
     key: key,
     className: 'item' + (index % 2 ? '' : ' even'),
     style: {
@@ -32285,7 +32236,7 @@ renderVariableHeightItem.toJSON = function () {
 };
 
 var renderVariableWidthItem = function renderVariableWidthItem(index, key) {
-  return /*#__PURE__*/_react["default"].createElement("div", {
+  return _react["default"].createElement("div", {
     key: key,
     className: 'item' + (index % 2 ? '' : ' even'),
     style: {
@@ -32299,7 +32250,7 @@ renderVariableWidthItem.toJSON = function () {
 };
 
 var renderGridLine = function renderGridLine(row, key) {
-  return /*#__PURE__*/_react["default"].createElement(_["default"], {
+  return _react["default"].createElement(_["default"], {
     axis: "x",
     key: key,
     length: 10000,
@@ -32373,7 +32324,7 @@ var examples = [{
   useTranslate3d: true
 }];
 
-var Examples = /*#__PURE__*/function (_Component) {
+var Examples = function (_Component) {
   _inherits(Examples, _Component);
 
   var _super = _createSuper(Examples);
@@ -32388,30 +32339,30 @@ var Examples = /*#__PURE__*/function (_Component) {
     key: "renderExamples",
     value: function renderExamples() {
       return examples.map(function (props, key) {
-        return /*#__PURE__*/_react["default"].createElement("div", {
+        return _react["default"].createElement("div", {
           key: key,
           className: "example axis-".concat(props.axis)
-        }, /*#__PURE__*/_react["default"].createElement("strong", null, "Props"), /*#__PURE__*/_react["default"].createElement("pre", {
+        }, _react["default"].createElement("strong", null, "Props"), _react["default"].createElement("pre", {
           className: "props"
-        }, JSON.stringify(props, null, 2)), /*#__PURE__*/_react["default"].createElement("strong", null, "Component"), /*#__PURE__*/_react["default"].createElement("div", {
+        }, JSON.stringify(props, null, 2)), _react["default"].createElement("strong", null, "Component"), _react["default"].createElement("div", {
           className: "component"
-        }, /*#__PURE__*/_react["default"].createElement(_["default"], props)));
+        }, _react["default"].createElement(_["default"], props)));
       });
     }
   }, {
     key: "render",
     value: function render() {
-      return /*#__PURE__*/_react["default"].createElement("div", {
+      return _react["default"].createElement("div", {
         className: "index"
-      }, /*#__PURE__*/_react["default"].createElement("a", {
+      }, _react["default"].createElement("a", {
         className: "banner",
         href: "https://github.com/caseywebdev/react-list"
-      }, /*#__PURE__*/_react["default"].createElement("img", {
+      }, _react["default"].createElement("img", {
         src: "https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67",
         alt: "Fork me on GitHub"
-      })), /*#__PURE__*/_react["default"].createElement("div", {
+      })), _react["default"].createElement("div", {
         className: "header"
-      }, "ReactList"), /*#__PURE__*/_react["default"].createElement("div", {
+      }, "ReactList"), _react["default"].createElement("div", {
         className: "examples"
       }, this.renderExamples()));
     }
@@ -32420,6 +32371,6 @@ var Examples = /*#__PURE__*/function (_Component) {
   return Examples;
 }(_react.Component);
 
-(0, _reactDom.render)( /*#__PURE__*/_react["default"].createElement(Examples, null), document.getElementById('main'));
+(0, _reactDom.render)(_react["default"].createElement(Examples, null), document.getElementById('main'));
 });
 Cogs.require("docs/index.es6");

--- a/docs/index.js
+++ b/docs/index.js
@@ -31605,7 +31605,8 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
     _createClass(ReactList, [{
       key: "componentDidMount",
       value: function componentDidMount() {
-        this.updateFrame = this.updateFrame.bind(this);
+        this.updateFrame = this.updateFrame.bind(this); // @superhuman fork: Call this function instead of `updateFrameAndClearCache`
+
         this.updateFrameAsync = this.updateFrameAsync.bind(this);
         window.addEventListener('resize', this.updateFrameAsync);
         this.updateFrame(this.scrollTo.bind(this, this.props.initialIndex));
@@ -31645,7 +31646,8 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
       value: function componentWillUnmount() {
         window.removeEventListener('resize', this.updateFrameAsync);
         this.scrollParent.removeEventListener('scroll', this.updateFrameAsync, PASSIVE);
-        this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE);
+        this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE); // @superhuman fork: Clean up anything that was added in forked code.
+
         window.cancelAnimationFrame(this.frameRequested);
       }
     }, {
@@ -31777,7 +31779,15 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
       key: "clearSizeCache",
       value: function clearSizeCache() {
         this.cachedScrollPosition = null;
-      } // Called by 'scroll' and 'resize' events, clears scroll position cache.
+      }
+      /*
+       * @superhuman fork
+       *
+       * This function only exists on this fork, and is a substitute for
+       * `updateFrameAndClearCache` (at the time of writing).
+       *
+       * Called by 'scroll' and 'resize' events, clears scroll position cache.
+       */
 
     }, {
       key: "updateFrameAsync",
@@ -31789,17 +31799,26 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
         this.clearSizeCache();
         this.frameRequested = window.requestAnimationFrame(this.updateFrame);
       }
+      /*
+       * @superhuman fork
+       * This function only exists on this fork, and lets
+       * the `getVisibleRange` function return correct value
+       * after `updateFrameAsync` has finished setting state.
+       */
+
     }, {
       key: "waitForFrameUpdate",
       value: function waitForFrameUpdate() {
+        var _this3 = this;
+
         if (!this._waitForFrameUpdate) {
           this._waitForFrameUpdate = new Promise(function (resolve) {
-            this.onFrameUpdate = function () {
+            _this3.onFrameUpdate = function () {
               resolve();
-              this.onFrameUpdate = null;
-              this._waitForFrameUpdate = null;
-            }.bind(this);
-          }.bind(this));
+              _this3.onFrameUpdate = null;
+              _this3._waitForFrameUpdate = null;
+            };
+          });
         }
 
         return this._waitForFrameUpdate;
@@ -31813,14 +31832,24 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
 
         switch (this.props.type) {
           case 'simple':
-            return this.updateSimpleFrame(cb);
+            this.updateSimpleFrame(cb);
+            break;
 
           case 'variable':
-            return this.updateVariableFrame(cb);
+            this.updateVariableFrame(cb);
+            break;
 
           case 'uniform':
-            return this.updateUniformFrame(cb);
+            this.updateUniformFrame(cb);
+            break;
         }
+        /*
+         * @superhuman fork
+         * The following block needs to run every time
+         * this function is called, (not just in the `default`
+         * case above), hence the `break`s instead of `return`s.
+         */
+
 
         if (this.onFrameUpdate) {
           this.onFrameUpdate();
@@ -32060,7 +32089,7 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
     }, {
       key: "renderItems",
       value: function renderItems() {
-        var _this3 = this;
+        var _this4 = this;
 
         var _this$props6 = this.props,
             itemRenderer = _this$props6.itemRenderer,
@@ -32068,20 +32097,20 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
         var _this$state5 = this.state,
             from = _this$state5.from,
             size = _this$state5.size;
-        var items = [];
+        var items = []; // @superhuman fork: Pass `size` to the item renderer
 
         for (var i = 0; i < size; ++i) {
           items.push(itemRenderer(from + i, i, size));
         }
 
         return itemsRenderer(items, function (c) {
-          return _this3.items = c;
+          return _this4.items = c;
         });
       }
     }, {
       key: "render",
       value: function render() {
-        var _this4 = this;
+        var _this5 = this;
 
         var _this$props7 = this.props,
             axis = _this$props7.axis,
@@ -32117,7 +32146,7 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
         return /*#__PURE__*/_react["default"].createElement("div", {
           style: style,
           ref: function ref(c) {
-            return _this4.el = c;
+            return _this5.el = c;
           }
         }, /*#__PURE__*/_react["default"].createElement("div", {
           style: listStyle

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/react-list",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/react-list",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "author": "Casey Foster <c@sey.me>",
   "license": "MIT",
   "main": "react-list.js",

--- a/react-list.es6
+++ b/react-list.es6
@@ -330,11 +330,14 @@ module.exports = class ReactList extends Component {
     if (typeof cb != 'function') cb = NOOP;
     switch (this.props.type) {
       case 'simple':
-        return this.updateSimpleFrame(cb);
+        this.updateSimpleFrame(cb);
+        break;
       case 'variable':
-        return this.updateVariableFrame(cb);
+        this.updateVariableFrame(cb);
+        break;
       case 'uniform':
-        return this.updateUniformFrame(cb);
+        this.updateUniformFrame(cb);
+        break;
     }
     if (this.onFrameUpdate) {
       this.onFrameUpdate();

--- a/react-list.es6
+++ b/react-list.es6
@@ -143,7 +143,10 @@ module.exports = class ReactList extends Component {
 
   componentDidMount() {
     this.updateFrame = this.updateFrame.bind(this);
+
+    // @superhuman fork: Call this function instead of `updateFrameAndClearCache`
     this.updateFrameAsync = this.updateFrameAsync.bind(this);
+
     window.addEventListener('resize', this.updateFrameAsync);
     this.updateFrame(this.scrollTo.bind(this, this.props.initialIndex));
   }
@@ -184,6 +187,8 @@ module.exports = class ReactList extends Component {
       PASSIVE
     );
     this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE);
+
+    // @superhuman fork: Clean up anything that was added in forked code.
     window.cancelAnimationFrame(this.frameRequested);
   }
 
@@ -299,7 +304,14 @@ module.exports = class ReactList extends Component {
     this.cachedScrollPosition = null;
   }
 
-  // Called by 'scroll' and 'resize' events, clears scroll position cache.
+  /*
+   * @superhuman fork
+   *
+   * This function only exists on this fork, and is a substitute for
+   * `updateFrameAndClearCache` (at the time of writing).
+   *
+   * Called by 'scroll' and 'resize' events, clears scroll position cache.
+   */
   updateFrameAsync() {
     if (this.frameRequested) {
       return;
@@ -308,6 +320,12 @@ module.exports = class ReactList extends Component {
     this.frameRequested = window.requestAnimationFrame(this.updateFrame);
   }
 
+  /*
+   * @superhuman fork
+   * This function only exists on this fork, and lets
+   * the `getVisibleRange` function return correct value
+   * after `updateFrameAsync` has finished setting state.
+   */
   waitForFrameUpdate() {
     if (!this._waitForFrameUpdate) {
       this._waitForFrameUpdate = new Promise(
@@ -339,6 +357,12 @@ module.exports = class ReactList extends Component {
         this.updateUniformFrame(cb);
         break;
     }
+    /*
+     * @superhuman fork
+     * The following block needs to run every time
+     * this function is called, (not just in the `default`
+     * case above), hence the `break`s instead of `return`s.
+     */
     if (this.onFrameUpdate) {
       this.onFrameUpdate();
     }
@@ -531,7 +555,10 @@ module.exports = class ReactList extends Component {
     const { itemRenderer, itemsRenderer } = this.props;
     const { from, size } = this.state;
     const items = [];
+
+    // @superhuman fork: Pass `size` to the item renderer
     for (let i = 0; i < size; ++i) items.push(itemRenderer(from + i, i, size));
+
     return itemsRenderer(items, c => (this.items = c));
   }
 

--- a/react-list.es6
+++ b/react-list.es6
@@ -328,15 +328,13 @@ module.exports = class ReactList extends Component {
    */
   waitForFrameUpdate() {
     if (!this._waitForFrameUpdate) {
-      this._waitForFrameUpdate = new Promise(
-        function (resolve) {
-          this.onFrameUpdate = function () {
-            resolve();
-            this.onFrameUpdate = null;
-            this._waitForFrameUpdate = null;
-          }.bind(this);
-        }.bind(this)
-      );
+      this._waitForFrameUpdate = new Promise(resolve => {
+        this.onFrameUpdate = () => {
+          resolve();
+          this.onFrameUpdate = null;
+          this._waitForFrameUpdate = null;
+        };
+      });
     }
 
     return this._waitForFrameUpdate;

--- a/react-list.js
+++ b/react-list.js
@@ -89,10 +89,7 @@
     y: 'height'
   };
 
-  var NOOP = function NOOP() {}; // If a browser doesn't support the `options` argument to
-  // add/removeEventListener, we need to check, otherwise we will
-  // accidentally set `capture` with a truthy value.
-
+  var NOOP = function NOOP() {};
 
   var PASSIVE = function () {
     if (typeof window === 'undefined') return false;
@@ -106,8 +103,7 @@
         }
 
       });
-    } catch (e) {// noop
-    }
+    } catch (e) {}
 
     return hasSupport;
   }() ? {
@@ -172,7 +168,7 @@
     });
   };
 
-  module.exports = (_temp = _class = /*#__PURE__*/function (_Component) {
+  module.exports = (_temp = _class = function (_Component) {
     _inherits(ReactList, _Component);
 
     var _super = _createSuper(ReactList);
@@ -207,8 +203,7 @@
     _createClass(ReactList, [{
       key: "componentDidMount",
       value: function componentDidMount() {
-        this.updateFrame = this.updateFrame.bind(this); // @superhuman fork: Call this function instead of `updateFrameAndClearCache`
-
+        this.updateFrame = this.updateFrame.bind(this);
         this.updateFrameAsync = this.updateFrameAsync.bind(this);
         window.addEventListener('resize', this.updateFrameAsync);
         this.updateFrame(this.scrollTo.bind(this, this.props.initialIndex));
@@ -218,9 +213,7 @@
       value: function componentDidUpdate(prevProps) {
         var _this2 = this;
 
-        // Viewport scroll is no longer useful if axis changes
-        if (this.props.axis !== prevProps.axis) this.clearSizeCache(); // If the list has reached an unstable state, prevent an infinite loop.
-
+        if (this.props.axis !== prevProps.axis) this.clearSizeCache();
         if (this.unstable) return;
 
         if (++this.updateCounter > MAX_SYNC_UPDATES) {
@@ -248,8 +241,7 @@
       value: function componentWillUnmount() {
         window.removeEventListener('resize', this.updateFrameAsync);
         this.scrollParent.removeEventListener('scroll', this.updateFrameAsync, PASSIVE);
-        this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE); // @superhuman fork: Clean up anything that was added in forked code.
-
+        this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE);
         window.cancelAnimationFrame(this.frameRequested);
       }
     }, {
@@ -273,7 +265,6 @@
     }, {
       key: "getScrollPosition",
       value: function getScrollPosition() {
-        // Cache scroll position as this causes a forced synchronous layout.
         if (typeof this.cachedScrollPosition === 'number') {
           return this.cachedScrollPosition;
         }
@@ -281,10 +272,7 @@
         var scrollParent = this.scrollParent;
         var axis = this.props.axis;
         var scrollKey = SCROLL_START_KEYS[axis];
-        var actual = scrollParent === window ? // Firefox always returns document.body[scrollKey] as 0 and Chrome/Safari
-        // always return document.documentElement[scrollKey] as 0, so take
-        // whichever has a value.
-        document.body[scrollKey] || document.documentElement[scrollKey] : scrollParent[scrollKey];
+        var actual = scrollParent === window ? document.body[scrollKey] || document.documentElement[scrollKey] : scrollParent[scrollKey];
         var max = this.getScrollSize() - this.props.scrollParentViewportSizeGetter(this);
         var scroll = Math.max(0, Math.min(actual, max));
         var el = this.getEl();
@@ -355,11 +343,7 @@
 
         var itemEls = this.items.children;
         if (!itemEls.length) return {};
-        var firstEl = itemEls[0]; // Firefox has a problem where it will return a *slightly* (less than
-        // thousandths of a pixel) different size for the same element between
-        // renders. This can cause an infinite render loop, so only change the
-        // itemSize when it is significantly different.
-
+        var firstEl = itemEls[0];
         var firstElSize = firstEl[OFFSET_SIZE_KEYS[axis]];
         var delta = Math.abs(firstElSize - itemSize);
         if (isNaN(delta) || delta >= 1) itemSize = firstElSize;
@@ -382,15 +366,6 @@
       value: function clearSizeCache() {
         this.cachedScrollPosition = null;
       }
-      /*
-       * @superhuman fork
-       *
-       * This function only exists on this fork, and is a substitute for
-       * `updateFrameAndClearCache` (at the time of writing).
-       *
-       * Called by 'scroll' and 'resize' events, clears scroll position cache.
-       */
-
     }, {
       key: "updateFrameAsync",
       value: function updateFrameAsync() {
@@ -401,13 +376,6 @@
         this.clearSizeCache();
         this.frameRequested = window.requestAnimationFrame(this.updateFrame);
       }
-      /*
-       * @superhuman fork
-       * This function only exists on this fork, and lets
-       * the `getVisibleRange` function return correct value
-       * after `updateFrameAsync` has finished setting state.
-       */
-
     }, {
       key: "waitForFrameUpdate",
       value: function waitForFrameUpdate() {
@@ -445,13 +413,6 @@
             this.updateUniformFrame(cb);
             break;
         }
-        /*
-         * @superhuman fork
-         * The following block needs to run every time
-         * this function is called, (not just in the `default`
-         * case above), hence the `break`s instead of `return`s.
-         */
-
 
         if (this.onFrameUpdate) {
           this.onFrameUpdate();
@@ -467,13 +428,10 @@
         if (prev) {
           prev.removeEventListener('scroll', this.updateFrameAsync);
           prev.removeEventListener('mousewheel', NOOP);
-        } // If we have a new parent, cached parent dimensions are no longer useful.
-
+        }
 
         this.clearSizeCache();
-        this.scrollParent.addEventListener('scroll', this.updateFrameAsync, PASSIVE); // You have to attach mousewheel listener to the scrollable element.
-        // Just an empty listener. After that onscroll events will be fired synchronously.
-
+        this.scrollParent.addEventListener('scroll', this.updateFrameAsync, PASSIVE);
         this.scrollParent.addEventListener('mousewheel', NOOP, PASSIVE);
       }
     }, {
@@ -577,23 +535,20 @@
       key: "getSpaceBefore",
       value: function getSpaceBefore(index) {
         var cache = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-        if (cache[index] != null) return cache[index]; // Try the static itemSize.
-
+        if (cache[index] != null) return cache[index];
         var _this$state2 = this.state,
             itemSize = _this$state2.itemSize,
             itemsPerRow = _this$state2.itemsPerRow;
 
         if (itemSize) {
           return cache[index] = Math.floor(index / itemsPerRow) * itemSize;
-        } // Find the closest space to index there is a cached value for.
-
+        }
 
         var from = index;
 
         while (from > 0 && cache[--from] == null) {
           ;
-        } // Finally, accumulate sizes of items from - index.
-
+        }
 
         var space = cache[from] || 0;
 
@@ -633,19 +588,15 @@
         var _this$state3 = this.state,
             from = _this$state3.from,
             itemSize = _this$state3.itemSize,
-            size = _this$state3.size; // Try the static itemSize.
-
-        if (itemSize) return itemSize; // Try the itemSizeGetter.
-
-        if (itemSizeGetter) return itemSizeGetter(index); // Try the cache.
-
-        if (index in cache) return cache[index]; // Try the DOM.
+            size = _this$state3.size;
+        if (itemSize) return itemSize;
+        if (itemSizeGetter) return itemSizeGetter(index);
+        if (index in cache) return cache[index];
 
         if (type === 'simple' && index >= from && index < from + size && items) {
           var itemEl = items.children[index - from];
           if (itemEl) return itemEl[OFFSET_SIZE_KEYS[axis]];
-        } // Try the itemSizeEstimator.
-
+        }
 
         if (itemSizeEstimator) return itemSizeEstimator(index, cache);
       }
@@ -699,7 +650,7 @@
         var _this$state5 = this.state,
             from = _this$state5.from,
             size = _this$state5.size;
-        var items = []; // @superhuman fork: Pass `size` to the item renderer
+        var items = [];
 
         for (var i = 0; i < size; ++i) {
           items.push(itemRenderer(from + i, i, size));
@@ -745,12 +696,12 @@
           WebkitTransform: transform,
           transform: transform
         };
-        return /*#__PURE__*/_react["default"].createElement("div", {
+        return _react["default"].createElement("div", {
           style: style,
           ref: function ref(c) {
             return _this5.el = c;
           }
-        }, /*#__PURE__*/_react["default"].createElement("div", {
+        }, _react["default"].createElement("div", {
           style: listStyle
         }, items));
       }
@@ -776,12 +727,12 @@
   }), _defineProperty(_class, "defaultProps", {
     axis: 'y',
     itemRenderer: function itemRenderer(index, key) {
-      return /*#__PURE__*/_react["default"].createElement("div", {
+      return _react["default"].createElement("div", {
         key: key
       }, index);
     },
     itemsRenderer: function itemsRenderer(items, ref) {
-      return /*#__PURE__*/_react["default"].createElement("div", {
+      return _react["default"].createElement("div", {
         ref: ref
       }, items);
     },

--- a/react-list.js
+++ b/react-list.js
@@ -207,7 +207,8 @@
     _createClass(ReactList, [{
       key: "componentDidMount",
       value: function componentDidMount() {
-        this.updateFrame = this.updateFrame.bind(this);
+        this.updateFrame = this.updateFrame.bind(this); // @superhuman fork: Call this function instead of `updateFrameAndClearCache`
+
         this.updateFrameAsync = this.updateFrameAsync.bind(this);
         window.addEventListener('resize', this.updateFrameAsync);
         this.updateFrame(this.scrollTo.bind(this, this.props.initialIndex));
@@ -247,7 +248,8 @@
       value: function componentWillUnmount() {
         window.removeEventListener('resize', this.updateFrameAsync);
         this.scrollParent.removeEventListener('scroll', this.updateFrameAsync, PASSIVE);
-        this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE);
+        this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE); // @superhuman fork: Clean up anything that was added in forked code.
+
         window.cancelAnimationFrame(this.frameRequested);
       }
     }, {
@@ -379,7 +381,15 @@
       key: "clearSizeCache",
       value: function clearSizeCache() {
         this.cachedScrollPosition = null;
-      } // Called by 'scroll' and 'resize' events, clears scroll position cache.
+      }
+      /*
+       * @superhuman fork
+       *
+       * This function only exists on this fork, and is a substitute for
+       * `updateFrameAndClearCache` (at the time of writing).
+       *
+       * Called by 'scroll' and 'resize' events, clears scroll position cache.
+       */
 
     }, {
       key: "updateFrameAsync",
@@ -391,17 +401,26 @@
         this.clearSizeCache();
         this.frameRequested = window.requestAnimationFrame(this.updateFrame);
       }
+      /*
+       * @superhuman fork
+       * This function only exists on this fork, and lets
+       * the `getVisibleRange` function return correct value
+       * after `updateFrameAsync` has finished setting state.
+       */
+
     }, {
       key: "waitForFrameUpdate",
       value: function waitForFrameUpdate() {
+        var _this3 = this;
+
         if (!this._waitForFrameUpdate) {
           this._waitForFrameUpdate = new Promise(function (resolve) {
-            this.onFrameUpdate = function () {
+            _this3.onFrameUpdate = function () {
               resolve();
-              this.onFrameUpdate = null;
-              this._waitForFrameUpdate = null;
-            }.bind(this);
-          }.bind(this));
+              _this3.onFrameUpdate = null;
+              _this3._waitForFrameUpdate = null;
+            };
+          });
         }
 
         return this._waitForFrameUpdate;
@@ -415,14 +434,24 @@
 
         switch (this.props.type) {
           case 'simple':
-            return this.updateSimpleFrame(cb);
+            this.updateSimpleFrame(cb);
+            break;
 
           case 'variable':
-            return this.updateVariableFrame(cb);
+            this.updateVariableFrame(cb);
+            break;
 
           case 'uniform':
-            return this.updateUniformFrame(cb);
+            this.updateUniformFrame(cb);
+            break;
         }
+        /*
+         * @superhuman fork
+         * The following block needs to run every time
+         * this function is called, (not just in the `default`
+         * case above), hence the `break`s instead of `return`s.
+         */
+
 
         if (this.onFrameUpdate) {
           this.onFrameUpdate();
@@ -662,7 +691,7 @@
     }, {
       key: "renderItems",
       value: function renderItems() {
-        var _this3 = this;
+        var _this4 = this;
 
         var _this$props6 = this.props,
             itemRenderer = _this$props6.itemRenderer,
@@ -670,20 +699,20 @@
         var _this$state5 = this.state,
             from = _this$state5.from,
             size = _this$state5.size;
-        var items = [];
+        var items = []; // @superhuman fork: Pass `size` to the item renderer
 
         for (var i = 0; i < size; ++i) {
           items.push(itemRenderer(from + i, i, size));
         }
 
         return itemsRenderer(items, function (c) {
-          return _this3.items = c;
+          return _this4.items = c;
         });
       }
     }, {
       key: "render",
       value: function render() {
-        var _this4 = this;
+        var _this5 = this;
 
         var _this$props7 = this.props,
             axis = _this$props7.axis,
@@ -719,7 +748,7 @@
         return /*#__PURE__*/_react["default"].createElement("div", {
           style: style,
           ref: function ref(c) {
-            return _this4.el = c;
+            return _this5.el = c;
           }
         }, /*#__PURE__*/_react["default"].createElement("div", {
           style: listStyle


### PR DESCRIPTION
Summary of changes:
- Update `return` -> `break` in `updateFrameAsync` switch case. 
- Added comments in source file (`react-list.es6`) around each area of the forked codebase that differs from upstream.
- Replace `bind`s with arrow functions in `waitForFrameUpdate`.
- Exclude comments from built js files (`cogs.js` babel config)
- Bump to 0.8.17 